### PR TITLE
Readme: fix usage of emit() instead of trigger()

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ events
     next(new Error('You shall not pass'));
   });
 
-events.trigger('test', { data: 'data' }, function (err) {
+events.emit('test', { data: 'data' }, function (err) {
   // This is run after all of the event listeners are done
   console.log(err);
   // [Error: You shall not pass]


### PR DESCRIPTION
The README.md uses `event.trigger` (which does not exist) instead of `event.emit`.