### PR TITLE
Update AsyncEventEmitter.js

### DIFF
--- a/lib/AsyncEventEmitter.js
+++ b/lib/AsyncEventEmitter.js
@@ -18,7 +18,7 @@ util.inherits(AsyncEventEmitter, EventEmitter);
 
 AsyncEventEmitter.prototype.emit = function(event, data, callback) {
   var self = this,
-      listeners = self._events[event] || [];
+      listeners = self._events && self._events[event] ? self._events[event] : [];
 
   // Optional data argument
   if(!callback && typeof data === 'function') {


### PR DESCRIPTION
An error is thrown when attempting to emit an event when no events have been defined.

e.g. create the emitter and fire emit without calling on, etc.

In my case i have an event i am calling 'initialize' however i have not defined any listeners.

TypeError: Cannot read property 'initialize' of undefined
      at TestComponent.AsyncEventEmitter.emit (sdk/node_modules/async-eventemitter/lib/AsyncEventEmitter.js:21:31)