### PR TITLE
bugfix - clone array before iterating

### DIFF
--- a/lib/AsyncEventEmitter.js
+++ b/lib/AsyncEventEmitter.js
@@ -39,7 +39,7 @@ AsyncEventEmitter.prototype.emit = function(event, data, callback) {
   // A single listener is just a function not an array...
   listeners = Array.isArray(listeners) ? listeners : [listeners];
 
-  eachSeries(listeners, function (fn, next) {
+  eachSeries(listeners.slice(), function (fn, next) {
     var err;
 
     // Support synchronous functions


### PR DESCRIPTION
dont allow side affects to impact the array being iterated

minimal reproduction steps
```js
aee.once('event', ()=>{})
aee.once('event', ()=>{})
aee.emit('event')
```